### PR TITLE
fix(plugin): correct outDir path handling in buildDoneHook

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -6,7 +6,6 @@ import type { AstroIntegrationLogger } from "astro";
 import { extract, sanitizeHtml } from "./extract.js";
 import { getFilePath } from "./util.js";
 import { fileURLToPath } from "url";
-import * as path from "path";
 import * as jsdom from "jsdom";
 
 export async function buildDoneHook({
@@ -55,7 +54,8 @@ async function handlePage({ page, options, render, dir, logger }: HandlePageInpu
 
   // remove leading dist/ from the path
   await fs.writeFile(pngFile, resvg.render().asPng());
-  pngFile = pngFile.replace(path.join(process.cwd(), "dist"), "").replace(/\\/g, "/");
+  // dir.pathname accounts for the outDir build argument
+  pngFile = pngFile.replace(dir.pathname, "").replace(/\\/g, "/");
   if (pngFile.startsWith("/")) pngFile = pngFile.slice(1);
 
   // convert the image path to a URL


### PR DESCRIPTION
## Issue

When using the command `astro build`, developers can pass in an [`outDir`](https://docs.astro.build/en/reference/configuration-reference/#outdir) argument. The value of `dist` was hardcoded into the plugin, causing the hook to fail a build.

## Fix

This pull request includes changes to the `src/hook.ts` file to improve the handling of file paths and remove unnecessary imports. The most important changes are:

Codebase simplification:

* Removed the unnecessary import of `path` module. (`src/hook.ts`)
* Updated the `pngFile` path replacement logic to use `dir.pathname` instead of `path.join(process.cwd(), "dist")` to account for the `outDir` build argument. (`src/hook.ts`)