### PR TITLE
Fix Windows Path Handling Regression Introduced in v1.12.2

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -7,6 +7,7 @@ import { extract, sanitizeHtml } from "./extract.js";
 import { getFilePath } from "./util.js";
 import { fileURLToPath } from "url";
 import * as jsdom from "jsdom";
+import path from "path";
 
 export async function buildDoneHook({
   logger,
@@ -32,12 +33,19 @@ interface HandlePageInput {
 }
 
 async function handlePage({ page, options, render, dir, logger }: HandlePageInput) {
+  // gets the absolute path to the HTML file. E.g. /home/user/project/dist/blog/index.html
+  // fileURLToPath() converts the URL to a file path. Without it, the path would start with a leading slash on Windows
+  // systems, resulting in an invalid path.
   const htmlFile = getFilePath({ dir: fileURLToPath(dir), page: page.pathname });
+
+  // read the HTML file and parse it with jsdom
   const html = (await fs.readFile(htmlFile)).toString();
   const document = new jsdom.JSDOM(sanitizeHtml(html)).window.document;
 
+  // extract the OpenGraph properties from the HTML file
   const pageDetails = extract(document);
 
+  // render the image using Satori and Resvg
   const reactNode = await render({ ...page, ...pageDetails, dir, document });
   const svg = await satori(reactNode, options);
   const resvg = new Resvg(svg, {
@@ -50,27 +58,25 @@ async function handlePage({ page, options, render, dir, logger }: HandlePageInpu
     },
   });
 
-  let pngFile = htmlFile.replace(/\.html$/, ".png");
-
-  // remove leading dist/ from the path
+  // save the image as a PNG file. The file name is the same as the HTML file, but with a .png extension.
+  const pngFile = htmlFile.replace(/\.html$/, ".png");
   await fs.writeFile(pngFile, resvg.render().asPng());
-  // dir.pathname accounts for the outDir build argument
-  pngFile = pngFile.replace(dir.pathname, "").replace(/\\/g, "/");
-  if (pngFile.startsWith("/")) pngFile = pngFile.slice(1);
 
-  // convert the image path to a URL
-  let imageUrl = new URL(pageDetails.image).pathname;
-  // remove leading slash
-  imageUrl = imageUrl.slice(1);
+  // get the relative filesystem path to the PNG file from the output directory. E.g. blog/index.png
+  // path.relative() returns the relative path from the first argument to the second argument.
+  const relativePngFile = path.relative(fileURLToPath(dir), pngFile).replace(/\\/g, "/");
+
+  // convert the image path to a URL and remove the leading slash
+  const imageUrl = new URL(pageDetails.image).pathname.slice(1);
 
   // check that the og:image property matches the sitePath
-  if (imageUrl !== pngFile) {
+  if (imageUrl !== relativePngFile) {
     throw new Error(
-      `The og:image property in ${htmlFile} (${imageUrl}) does not match the generated image (${pngFile}).`,
+      `The og:image property in ${htmlFile} (${imageUrl}) does not match the generated image (${relativePngFile}).`,
     );
   }
 
   if (options.verbose) {
-    logger.info(`Generated ${pngFile} for ${htmlFile}.`);
+    logger.info(`Generated ${relativePngFile} for ${htmlFile}.`);
   }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `src/hook.ts` file aimed at improving how HTML files and their associated images are handled and processed.

### Documentation Enhancements

* [`src/hook.ts`](diffhunk://#diff-3f0d30441d44c825e178251d199e3ad61e2730d7a4d0ccbf882f8197bce87767R36-R48): Added inline comments to clarify the functionality of key code sections, including URL-to-file path conversion, HTML parsing with `jsdom`, extraction of OpenGraph metadata, and image rendering.

### Improved Path Handling

* [`src/hook.ts`](diffhunk://#diff-3f0d30441d44c825e178251d199e3ad61e2730d7a4d0ccbf882f8197bce87767L53-R80): Refactored the logic for saving PNG files by replacing manual string operations with `path.relative()` for better cross-platform compatibility.
* [`src/hook.ts`](diffhunk://#diff-3f0d30441d44c825e178251d199e3ad61e2730d7a4d0ccbf882f8197bce87767L53-R80): Replaced `dir.pathname` with `fileURLToPath(dir)` to prevent issues on Windows systems where paths incorrectly begin with a forward slash, which previously disrupted the og:image detection.